### PR TITLE
Correct URL for WordPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can see a prototype of this feature with [Lighthouse Viewer](http://bit.ly/l
 
 ## Contributing
 
-This is still under early development, but we would like to hear any suggestions from community members in the meantime. [WordPress](https://wordpress.com/) is the first ecosystem we would like to include before rolling this out for other stacks. 
+This is still under early development, but we would like to hear any suggestions from community members in the meantime. [WordPress](https://wordpress.org/) is the first ecosystem we would like to include before rolling this out for other stacks. 
 
 * If you are an active member of the WordPress community, feel free to provide suggestions for different audit messages to this [spreadsheet]( https://docs.google.com/spreadsheets/d/1D4sz4NmhTjekJR2HIFX6QvO76c9PU2LHKDBf19YLnrA/edit?usp=sharing).
 * Alternatively, feel free to open PRs and provide suggestions for different audit messages in [`wordpress/audits.json`](./wordpress/audits.json).


### PR DESCRIPTION
wordpress.com is a commercial service run by Automattic; it would be better to link to wordpress.org which is the site for the open source project.