### PR TITLE
next.js: use image component for preload-lcp-image rule

### DIFF
--- a/packs/next.js
+++ b/packs/next.js
@@ -21,6 +21,8 @@ const UIStrings = {
   'uses-responsive-images': 'Use the `next/image` component to set the appropriate `sizes`. [Learn more](https://nextjs.org/docs/api-reference/next/image#sizes).',
   /** Additional description of a Lighthouse audit that tells the user to analyze the performance of their applications using Next.js Analytics. */
   'user-timings': 'Consider using `Next.js Analytics` to measure your app\'s real-world performance. [Learn more](https://nextjs.org/docs/advanced-features/measuring-performance).',
+  /** Additional description of a Lighthouse audit that tells the user to use the next/image component to automatically preload LCP images. */
+  'preload-lcp-image': 'Use the `next/image` component and set "priority" to true to preload LCP image. [Learn more](https://nextjs.org/docs/api-reference/next/image#priority).',
 }
 
 module.exports = {


### PR DESCRIPTION
Next.js image component can automatically preload LCP image if
the `priority` attribute is set to true.

https://nextjs.org/docs/api-reference/next/image#priority
https://github.com/GoogleChrome/lighthouse/blob/master/lighthouse-core/audits/preload-lcp-image.js