### PR TITLE
CONTRIBUTING.md: Remove instructions to encode icon svg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,7 @@ Do you notice a specific audit string for a particular pack that is wrong or cou
 
 1. Acquire the logo in SVG
 1. Open in https://jakearchibald.github.io/svgomg/ apply default optimizations, tweak precision, and enable "Prefer viewBox to width/height". Copy out resulting markup.
-1. Paste into https://yoksel.github.io/url-encoder/. Copy out the _Encoded_ result.
-1. Inline icon markup in stackpack file as `data:image/svg+xml,` + _<encoded, optimized svg markup>_
+1. Inline icon markup in stackpack file as `data:image/svg+xml,` + _<optimized svg markup>_
 
 ## FAQ
 


### PR DESCRIPTION
It is not necessary to encode the SVG according to comment here by @connorjclark:
https://github.com/GoogleChrome/lighthouse-stack-packs/pull/66#discussion_r750798578