### PR TITLE
Next.js: add message for `unsized-images` audit

### DIFF
--- a/packs/next.js
+++ b/packs/next.js
@@ -23,6 +23,8 @@ const UIStrings = {
   'user-timings': 'Consider using `Next.js Analytics` to measure your app\'s real-world performance. [Learn more](https://nextjs.org/docs/advanced-features/measuring-performance).',
   /** Additional description of a Lighthouse audit that tells the user to use the next/image component to automatically preload LCP images. */
   'preload-lcp-image': 'Use the `next/image` component and set "priority" to true to preload LCP image. [Learn more](https://nextjs.org/docs/api-reference/next/image#priority).',
+  /** Additional description of a Lighthouse audit that tells the user to use the next/image component to make sure `width` and `height` of image elements are always specified. */
+  'unsized-images': 'Use the `next/image` component to make sure images are always sized appropriately. [Learn more](https://nextjs.org/docs/api-reference/next/image#width).',
 }
 
 module.exports = {


### PR DESCRIPTION
Suggest users to use the `next/image` component which requires `width` and `height` of
image elements to be explicitly specified. In some cases, like statically imported images,
the component can automatically detect `width` and `height`.