### PR TITLE
update ezoic pack: Remove discontinued setting, update product link

### DIFF
--- a/packs/ezoic.js
+++ b/packs/ezoic.js
@@ -2,31 +2,31 @@ const icon = `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox
 
 const UIStrings = {
   /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Remove Unused CSS is a setting name. */
-  'unused-css-rules': 'Use [Ezoic Leap](https://pubdash.ezoic.com/speed) and enable `Remove Unused CSS` to help with this issue. It will identify the CSS classes that are actually used on each page of your site, and remove any others to keep the file size small.',
+  'unused-css-rules': 'Use [Ezoic Leap](https://pubdash.ezoic.com/leap) and enable `Remove Unused CSS` to help with this issue. It will identify the CSS classes that are actually used on each page of your site, and remove any others to keep the file size small.',
   /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Next-Gen Formats is a setting name.*/
-  'modern-image-formats': 'Use [Ezoic Leap](https://pubdash.ezoic.com/speed) and enable `Next-Gen Formats` to convert images to WebP.',
+  'modern-image-formats': 'Use [Ezoic Leap](https://pubdash.ezoic.com/leap) and enable `Next-Gen Formats` to convert images to WebP.',
   /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Lazy Load Images is a setting name.*/
-  'offscreen-images': 'Use [Ezoic Leap](https://pubdash.ezoic.com/speed) and enable `Lazy Load Images` to defer loading off-screen images until they are needed.',
-  /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Critical CSS is a setting name.*/
-  'render-blocking-resources': 'Use [Ezoic Leap](https://pubdash.ezoic.com/speed) and enable `Critical CSS` and `Script Delay` to defer non-critical JS/CSS.',
+  'offscreen-images': 'Use [Ezoic Leap](https://pubdash.ezoic.com/leap) and enable `Lazy Load Images` to defer loading off-screen images until they are needed.',
+  /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Script Delay is a setting name.*/
+  'render-blocking-resources': 'Use [Ezoic Leap](https://pubdash.ezoic.com/leap) and enable `Script Delay` to defer non-critical JS.',
   /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Minify CSS is a setting name.*/
-  'unminified-css': 'Use [Ezoic Leap](https://pubdash.ezoic.com/speed) and enable `Minify CSS` to automatically minify your CSS to reduce network payload sizes.',
+  'unminified-css': 'Use [Ezoic Leap](https://pubdash.ezoic.com/leap) and enable `Minify CSS` to automatically minify your CSS to reduce network payload sizes.',
   /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Minify Javascript is a setting name.*/
-  'unminified-javascript': 'Use [Ezoic Leap](https://pubdash.ezoic.com/speed) and enable `Minify Javascript` to automatically minify your JS to reduce network payload sizes.',
+  'unminified-javascript': 'Use [Ezoic Leap](https://pubdash.ezoic.com/leap) and enable `Minify Javascript` to automatically minify your JS to reduce network payload sizes.',
   /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Efficient Static Cache Policy is a setting name.*/
-  'uses-long-cache-ttl': 'Use [Ezoic Leap](https://pubdash.ezoic.com/speed) and enable `Efficient Static Cache Policy` to set recommended values in the caching header for static assests.',
+  'uses-long-cache-ttl': 'Use [Ezoic Leap](https://pubdash.ezoic.com/leap) and enable `Efficient Static Cache Policy` to set recommended values in the caching header for static assests.',
   /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Next-Gen Formats is a setting name.*/
-  'uses-optimized-images': 'Use [Ezoic Leap](https://pubdash.ezoic.com/speed) and enable `Next-Gen Formats` to convert images to WebP.',
+  'uses-optimized-images': 'Use [Ezoic Leap](https://pubdash.ezoic.com/leap) and enable `Next-Gen Formats` to convert images to WebP.',
   /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Resize Images is a setting name.*/
-  'uses-responsive-images': 'Use [Ezoic Leap](https://pubdash.ezoic.com/speed) and enable `Resize Images` to resize images to a device appropriate size, reducing network payload sizes.',
+  'uses-responsive-images': 'Use [Ezoic Leap](https://pubdash.ezoic.com/leap) and enable `Resize Images` to resize images to a device appropriate size, reducing network payload sizes.',
   /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Cloud Caching is Ezoic's CDN.*/
-  'server-response-time': 'Use [Ezoic Cloud Caching](https://pubdash.ezoic.com/speed/caching) to cache your content across our world wide network, improving time to first byte.',
+  'server-response-time': 'Use [Ezoic Cloud Caching](https://pubdash.ezoic.com/leap/caching) to cache your content across our world wide network, improving time to first byte.',
   /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Pre-Connect Origins is a setting name.*/
-  'uses-rel-preconnect': 'Use [Ezoic Leap](https://pubdash.ezoic.com/speed) and enable `Pre-Connect Origins` to automatically add `preconnect` resource hints to establish early connections to important third-party origins.',
+  'uses-rel-preconnect': 'Use [Ezoic Leap](https://pubdash.ezoic.com/leap) and enable `Pre-Connect Origins` to automatically add `preconnect` resource hints to establish early connections to important third-party origins.',
   /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Preload Fonts and Preload Background Images are setting names.*/
-  'uses-rel-preload': 'Use [Ezoic Leap](https://pubdash.ezoic.com/speed) and enable `Preload Fonts` and `Preload Background Images` to add `preload` links to prioritize fetching resources that are currently requested later in page load.',
+  'uses-rel-preload': 'Use [Ezoic Leap](https://pubdash.ezoic.com/leap) and enable `Preload Fonts` and `Preload Background Images` to add `preload` links to prioritize fetching resources that are currently requested later in page load.',
   /** Additional description of a Lighthouse audit for a third-party framework called `Ezoic`. This is displayed after a user expands the section to see more. No character length limits. Ezoic Leap is Ezoic's site speed improvement toolset. Optimize Fonts is a setting name.*/
-  'font-display': 'Use [Ezoic Leap](https://pubdash.ezoic.com/speed) and enable `Optimize Fonts` to automatically leverage the `font-display` CSS feature to ensure text is user-visible while webfonts are loading.',
+  'font-display': 'Use [Ezoic Leap](https://pubdash.ezoic.com/leap) and enable `Optimize Fonts` to automatically leverage the `font-display` CSS feature to ensure text is user-visible while webfonts are loading.',
 }
 
 module.exports = {


### PR DESCRIPTION
This change is primarily to remove a reference to a discontinued product setting, "Critical CSS"

The change also updates the product link, from `speed` to `leap`. Either of them redirect correctly to the same page, but `leap` is the current product name and preferred.